### PR TITLE
Require win32 from package.json os field

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "type": "git",
     "url": "https://github.com/wouterverweirder/kinect2.git"
   },
+  "os": [
+    "win32"
+  ],
   "binary": {
     "module_name": "kinect2",
     "module_path": "./build/{module_name}/v{version}/{configuration}/{node_abi}-{platform}-{arch}/",


### PR DESCRIPTION
This way, if `kinect2` is set as an `optionalDependency` of the host project, and the project can run on other platforms, `npm install` will not fail with a bunch of compile errors.

This package depends on MS Official Kinect 2 SDK, so it cannot run on other platforms anyway - no downside to this.